### PR TITLE
fix: 解决无法开始游戏，解决庄家使用手铐时无法正确判定，解决弹夹未清空前就获得新道具

### DIFF
--- a/nonebot_plugin_BR/__main__.py
+++ b/nonebot_plugin_BR/__main__.py
@@ -178,11 +178,10 @@ async def _(
                 game_data["player_name"],
             )
 
-        await LocalData.save_data(session_uid, game_data)
-        await matcher.finish("")
-
-    if not game_data["is_start"]:
         game_data["is_start"] = True
+        await LocalData.save_data(session_uid, game_data)
+        await matcher.finish()
+
     # 判断是否是自己回合
     logger.info(game_data["round_self"])
     logger.info(player_id == game_data["player_id2"])
@@ -317,8 +316,7 @@ async def _(
             game_data["items"]["drink"] -= 1
             await LocalData.save_data(session.get_id(SessionIdType.GROUP), game_data)
             await matcher.finish("饮料已使用,退弹一发")
-        else:
-            await matcher.finish("无效道具")
+        await matcher.finish("无效道具")
     else:
         if "刀" in txt:
             if game_data["eneny_items"]["knife"] <= 0:

--- a/nonebot_plugin_BR/game.py
+++ b/nonebot_plugin_BR/game.py
@@ -144,8 +144,8 @@ class Game:
         outmsg = False
 
         # 若手铐使用则跳过对方回合
-        if (game_data["one_choice"]["skip"] == 1 and game_data["round_self"]) or (
-            game_data["one_choice"]["skip"] == 2 and not game_data["round_self"]
+        if (game_data["one_choice"]["skip"] and game_data["round_self"]) or (
+            game_data["one_choice"]["skip"] and not game_data["round_self"]
         ):
             game_data["round_self"] = not game_data["round_self"]
             outmsg = True
@@ -168,7 +168,6 @@ class Game:
             msg = f"当前子弹数: {game_data['weapon_all']}\n实弹数: {sum(game_data['weapon_if'])}"
             if_reload = False
 
-        game_data, out_data, new_weapon1, new_weapon2 = await Weapon.new_item(game_data)
         await LocalData.save_data(session_uid, game_data)
         return if_reload, msg
 


### PR DESCRIPTION
1. 解决无法开始游戏 https://github.com/reine-ishyanami/nonebot_plugin_BR/commit/9c336b14157c842627246c89d8889296ccf0a265#diff-2ea1240ae1ae4a8a5fd7bc57fd09924580000c62c2b2cbe856da124a8602eb6bR180-R184
2. 解决庄家使用手铐时无法正确判定 https://github.com/reine-ishyanami/nonebot_plugin_BR/commit/9c336b14157c842627246c89d8889296ccf0a265#diff-681b07c38b92621177f98ff5b2f2d4f5f0663f7f86050e78e6db35fe251a9947R147-R148
3. 解决弹夹未清空前就获得新道具 https://github.com/reine-ishyanami/nonebot_plugin_BR/commit/9c336b14157c842627246c89d8889296ccf0a265#diff-681b07c38b92621177f98ff5b2f2d4f5f0663f7f86050e78e6db35fe251a9947L171